### PR TITLE
Fix: erro al crear una nueva cuenta

### DIFF
--- a/src/modules/board/Board.tsx
+++ b/src/modules/board/Board.tsx
@@ -4,7 +4,6 @@ import { useDocumentTitle } from '@uidotdev/usehooks'
 import { useSession } from '@/SessionProvider'
 import { useEffect, useState } from 'react'
 import { useSaveBoard } from './state/useSaveBoard'
-import { defaultBoard } from './models/board'
 import { LoadingBoard } from './components/LoadingBoard'
 
 export function Board({ children }: { children: React.ReactNode }) {
@@ -15,25 +14,22 @@ export function Board({ children }: { children: React.ReactNode }) {
 	const { session } = useSession()
 	useEffect(() => {
 		if(!!session) {
-			if(JSON.stringify(data) != JSON.stringify(defaultBoard)) {
-				setLoading(false)
-			}
+			setLoading(false)
 		}
 		useSaveBoard({ data, session })
 	}, [data])
 	
-	if(!!session && loading) {
-		return ( 
-			<LoadingBoard/> 
-		)
-	}
-
 	return (
 		<>
-			<div>
-				{children}
-			</div>
-			<WelcomeDialog />
+			{!!session && loading && <LoadingBoard/> }
+			{ 
+				loading == false && <>
+					<div>
+						{children}
+					</div>
+					<WelcomeDialog />
+				</>
+			}
 		</>
 	)
 }


### PR DESCRIPTION
Al crear una nueva cuenta el usuario queda estancado en el estado de loading, la falla se encontraba en la condición encargada de mostrar el componente LoadingBoard.