### PR TITLE
fix: Error al crear y modificar columnas

### DIFF
--- a/src/modules/columnList/hooks/useColumnList.tsx
+++ b/src/modules/columnList/hooks/useColumnList.tsx
@@ -1,29 +1,8 @@
 import { RootState } from '@/store'
 import { useSelector } from 'react-redux'
 import { Column } from '../models/column'
-import { isDefaultColumnList } from '../models/columnList'
-import { useTranslation } from 'react-i18next'
-import { useMemo } from 'react'
 
 export const useColumnList = (): Column[] => {
-	const { t } = useTranslation()
 	const columnList = useSelector((state: RootState) => state.columnList.list)
-
-	return useMemo(() => {
-		if (!isDefaultColumnList(columnList)) {
-			return columnList
-		}
-
-		const translateColumnName = columnList.map((column) => {
-			const key = `default_columns.${column.id}`
-			const translatedName = t(key)
-
-			return {
-				...column,
-				name: translatedName,
-			}
-		})
-
-		return translateColumnName
-	}, [columnList, t])
+	return columnList
 }

--- a/src/modules/columnList/state/useSaveColumnList.tsx
+++ b/src/modules/columnList/state/useSaveColumnList.tsx
@@ -2,7 +2,7 @@ import { useSession } from '@/SessionProvider'
 import { ColumnList, defaultColumnList } from '../models/columnList'
 import LocalStorageColumnListRepository from './localStorageColumnList'
 import { sendForSaveColumnList } from './sendForSaveColumnList'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 interface useSaveColumnListParams {
 	columnList: ColumnList
@@ -10,14 +10,21 @@ interface useSaveColumnListParams {
 
 export const useSaveColumnList = ({ columnList }: useSaveColumnListParams) => {
 	const { session } = useSession()
+	const columnListRef = useRef(columnList)
 	useEffect(() => {
 		const localStorage = new LocalStorageColumnListRepository()
 		const localColumnList = localStorage.getAll()
 
-		if (JSON.stringify(columnList) !== JSON.stringify(defaultColumnList)) {
+		const isNotColumnListByDefault =
+			JSON.stringify(columnList) !== JSON.stringify(defaultColumnList)
+		const beforeWasNotColumnListByDefault =
+			JSON.stringify(columnListRef.current) !== JSON.stringify(defaultColumnList)
+
+		if (isNotColumnListByDefault || beforeWasNotColumnListByDefault) {
 			const isNotTheLocalColumnList =
 				JSON.stringify(columnList) !== JSON.stringify(localColumnList)
-			if (!!session && isNotTheLocalColumnList) {
+			columnListRef.current = columnList
+			if (session && isNotTheLocalColumnList) {
 				sendForSaveColumnList(columnList)
 			} else {
 				localStorage.save(columnList)


### PR DESCRIPTION
* No se aplicaban los cambios en los nombres de las columnas.
* Se era posible eliminar una columna luego de crearla (Error condicional). 