### PR TITLE
Soluciona error relacionado a las etiquetas

### DIFF
--- a/src/auth/utils/getActualUserBoard.ts
+++ b/src/auth/utils/getActualUserBoard.ts
@@ -1,5 +1,4 @@
 import LocalStorageNotesRepository from '@/modules/notes/repository/LocalStorageNotesRepository'
-import { eisenhowerTagGroup } from '@/modules/taskList/Tags/model/defaultTags'
 import { store } from '@/store'
 import { UserBoardOnDB } from '../model/UserBoardOnDB'
 import { getUserId } from './getUserId'
@@ -12,7 +11,7 @@ export const getActualUserBoard = async (): Promise<UserBoardOnDB> => {
 		task_list_in_each_column: store.getState().taskListInEachColumn.list,
 		user_id: await getUserId(),
 		notes,
-		actual_tag_group: eisenhowerTagGroup,
+		actual_tag_group: store.getState().tags.actualTagGroup,
 		reminders: store.getState().reminder.reminder,
 	}
 }

--- a/src/modules/taskList/Tags/state/tagsReducer.ts
+++ b/src/modules/taskList/Tags/state/tagsReducer.ts
@@ -5,7 +5,7 @@ import { addTagGroup } from './actions/addTagGroup'
 
 interface InitialState {
 	list: AvailableTags
-	actualTagGroup?: TagGroup
+	actualTagGroup: TagGroup
 	userSelectedTags: Tag[]
 }
 const initialState: InitialState = {


### PR DESCRIPTION
A veces las al iniciar sesión no se establece el grupo de etiquetas que se había seleccionado anteriormente sino que aparecen establecidas las etiquetas por defecto.