### PR TITLE
implementa: nueva regla de negocio para el registro de cambios de una tarea

### DIFF
--- a/src/modules/taskList/useCase/addChangeToTaskTimelineHistory.test.ts
+++ b/src/modules/taskList/useCase/addChangeToTaskTimelineHistory.test.ts
@@ -87,6 +87,33 @@ describe('addChangeToTaskTimelineHistory', () => {
 		})
 	})
 
+	test('No se debe agregar un nuevo registro al historial si el columnName es identico al columnName del ultimo registro existente.', () => {
+		const mockDate1 = new Date('2024-01-15T10:00:00.000Z')
+		const mockDate2 = new Date('2024-01-15T11:00:00.000Z')
+
+		const task: taskModel = {
+			timelineHistory: [
+				{
+					date: mockDate1,
+					columnName: 'En Progreso',
+				},
+			],
+		} as taskModel
+
+		vi.spyOn(global, 'Date').mockImplementation(() => mockDate2 as Date)
+
+		const result = addChangeToTaskTimelineHistory({
+			task,
+			columnName: 'En Progreso',
+		})
+
+		expect(result).toHaveLength(1)
+		expect(result[0]).toEqual({
+			date: mockDate1,
+			columnName: 'En Progreso',
+		})
+	})
+
 	test('No debe mutar el historial original de la tarea.', () => {
 		const mockDate1 = new Date('2024-01-15T10:00:00.000Z')
 		const mockDate2 = new Date('2024-01-15T11:00:00.000Z')

--- a/src/modules/taskList/useCase/addChangeToTaskTimelineHistory.ts
+++ b/src/modules/taskList/useCase/addChangeToTaskTimelineHistory.ts
@@ -21,12 +21,18 @@ export const addChangeToTaskTimelineHistory = ({
 		throw new BusinessError('columnName no puede estar vacio')
 	}
 
+	const actualTaskTimelineHistory = task.timelineHistory || defaultTaskTimelineHistory
+
+	const lastChange = actualTaskTimelineHistory[actualTaskTimelineHistory.length - 1]
+	const lastColumnName = lastChange ? lastChange.columnName : ''
+	if (columnName === lastColumnName) {
+		return actualTaskTimelineHistory
+	}
+
 	const newChange: TaskColumnChange = {
 		date: new Date(),
 		columnName,
 	}
-
-	const actualTaskTimelineHistory = task.timelineHistory || defaultTaskTimelineHistory
 
 	return [...actualTaskTimelineHistory, newChange]
 }


### PR DESCRIPTION
Ya no es posible agregar un nuevo registro al historial si el columnName es idéntico al columnName del ultimo registro existente. Antes esto era posible cuando el usuario hacia drag&drop de una tarea sobre una misma columna lo cual creava duplicidad en el registro de cambios.

Antes esto era posible:

```
Pendientes - 27/10/25, 2:53

Procesando- 1/11/25, 0:30
Procesando - 1/11/25, 1:11

Pendientes - 1/11/25, 1:15
Procesando - 1/11/25, 16:50
Finalizado - 1/11/25, 17:08
Archivado - 1/11/25, 17:09
```